### PR TITLE
Add a basic REST API and a serve command 

### DIFF
--- a/counterfit/commands/serve.py
+++ b/counterfit/commands/serve.py
@@ -16,7 +16,7 @@ parser.add_argument("-t", "--terminate", action="store_true", help="Stop the RES
 @cmd2.with_category("Counterfit Commands")
 @cmd2.with_argparser(parser)
 def do_serve(self, args):
-    """Servepredictions with a REST API"""
+    """ Serve predictions with a REST API"""
     if args.start:
         port = args.port
         self.pwarning("\n Starting the server on port {}.".format(port))

--- a/counterfit/commands/serve.py
+++ b/counterfit/commands/serve.py
@@ -1,0 +1,38 @@
+from counterfit.core.state import CFState
+from counterfit.core.server import Server
+
+import argparse
+import cmd2
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-p", "--port", type=int, default=13337, help="The port to run the server on.")
+parser.add_argument("-s", "--start", action="store_true", help="Start the REST API server.")
+parser.add_argument("-t", "--terminate", action="store_true", help="Stop the REST API server.")
+
+
+
+
+@cmd2.with_category("Counterfit Commands")
+@cmd2.with_argparser(parser)
+def do_serve(self, args):
+    """Servepredictions with a REST API"""
+    if args.start:
+        port = args.port
+        self.pwarning("\n Starting the server on port {}.".format(port))
+        try:
+            server = Server.get_instance(port=port)
+        except Server.ServerRunningException as e:
+            self.pwarning("\n [!] Another server instance is already running on port {}. \n [!] Please first stop that instance with the serve -t command.".format(e))
+            return
+        server.serve()
+
+    if args.terminate:
+        try:
+            server =Server.get_instance()
+        except Server.ServerNotRunningException:
+           self.pwarning("\n [!] You must launch the server before invoking the termination command.") 
+           return
+        self.pwarning("\n Stoping the server.")
+        server.shutdown()
+

--- a/counterfit/core/server.py
+++ b/counterfit/core/server.py
@@ -51,7 +51,7 @@ class Server():
            Server.__instance = self
    
    def __app_factory(self):
-       """Create the flask app that exposes the api"""
+       """ Create the flask app that exposes the api"""
        app = Flask(__name__)
        
        @app.route("/predict")
@@ -87,7 +87,7 @@ class Server():
    def __run_flask(self, port):
        self.app.run(port=self.port)
    def __predict(self, args):
-       """Clone of the command do_predict function which I could not call directly"""
+       """ Clone of the command do_predict function which could not be called directly"""
        if CFState.get_instance().active_target is None:
            print("\n [!] must first `interact` with a target.\n")
            return
@@ -115,7 +115,7 @@ class Server():
 
 
 def set_attack_samples(target, sample_index=0):
-    # Duplicated as I could not import commands as a module
+    # Duplicated as commands could not be imported as a module
     if hasattr(sample_index, "__iter__"):
         # (unused) multiple index
         out = np.array([target.X[i] for i in sample_index])

--- a/counterfit/core/server.py
+++ b/counterfit/core/server.py
@@ -1,0 +1,132 @@
+from counterfit.core.state import CFState
+from counterfit.core.run_scan_utils import get_printable_batch, printable_numpy
+
+import threading
+import numpy as np
+from flask import Flask
+from flask import request, jsonify
+from werkzeug.serving import make_server
+from typing import Any, List
+
+class ServerThread(threading.Thread):
+    """ Run the Flask app in a separate thread in the background"""
+    # From https://stackoverflow.com/questions/15562446/how-to-stop-flask-application-without-using-ctrl-c
+    def __init__(self, app, port=None):
+        threading.Thread.__init__(self)
+        self.srv = make_server('127.0.0.1', port, app)
+        self.ctx = app.app_context()
+        self.ctx.push()
+
+    def run(self):
+        self.srv.serve_forever()
+
+    def shutdown_thread(self):
+        self.srv.shutdown()
+
+
+class Server():
+   """ Singleton server instance"""
+   __instance = None
+   
+   class ServerRunningException(Exception):
+       # Constructor
+       def __init__(self, port):
+           self.port = port
+
+       # __str__ is to print() the port
+       def __str__(self):
+           return(repr(self.port))
+
+   class ServerNotRunningException(Exception):
+       #Placeholder exception
+       pass 
+
+   def __init__(self, port):
+       if Server.__instance != None:
+           raise Server.ServerRunningException(Server.get_instance().port)
+       else:
+           self.port=port
+           self.app=self.__app_factory()
+           self.thread=ServerThread(self.app, port=self.port)
+           Server.__instance = self
+   
+   def __app_factory(self):
+       """Create the flask app that exposes the api"""
+       app = Flask(__name__)
+       
+       @app.route("/predict")
+       def predict_endpoint():
+           index = request.args.get('index')
+           args = {'index':index}
+           json = self.__predict(args)
+           return jsonify(json)
+       return app
+
+   @staticmethod 
+   def get_instance(port=None):
+       # Return the server if requested
+       if port is None:
+           if Server.__instance == None:
+               raise Server.ServerNotRunningException()
+           else:
+               return Server.__instance
+       # Create the instance if necessary
+       try:
+           Server(port)
+       except:
+           raise
+       return Server.__instance
+
+   def shutdown(self):
+       self.thread.shutdown_thread()
+       Server.__instance=None
+
+   def serve(self):
+       self.thread.start()
+       
+   def __run_flask(self, port):
+       self.app.run(port=self.port)
+   def __predict(self, args):
+       """Clone of the command do_predict function which I could not call directly"""
+       if CFState.get_instance().active_target is None:
+           print("\n [!] must first `interact` with a target.\n")
+           return
+       else:
+           target = CFState.get_instance().active_target
+       if 'index' in args:  # default behavior
+           sample_index = int(args['index'])
+           samples = set_attack_samples(target, sample_index)
+       elif target.active_attack is not None and target.active_attack.sample_index is not None:
+           sample_index = target.active_attack.sample_index
+           samples = set_attack_samples(target, sample_index)        
+       else:
+           sample_index = random.randint(0, len(target.X) - 1)
+           samples = set_attack_samples(target, sample_index)
+
+       result = target._submit(samples)
+       str(target.model_output_classes).replace(',', '')
+
+       if not hasattr(sample_index, "__iter__"):
+           sample_index = [sample_index]
+       samples_str = get_printable_batch(target, samples)
+       results_str = printable_numpy(result)
+       
+       return {"sample_index": sample_index,"results": results_str,"samples": samples_str}
+
+
+def set_attack_samples(target, sample_index=0):
+    # Duplicated as I could not import commands as a module
+    if hasattr(sample_index, "__iter__"):
+        # (unused) multiple index
+        out = np.array([target.X[i] for i in sample_index])
+        batch_shape = (-1,) + target.model_input_shape
+    elif type(target.X[sample_index]) is str:
+        # array of strings (textattack)
+        out = np.array(target.X[sample_index])
+        batch_shape = (-1,)
+    else:
+        # array of arrays (art)
+        out = np.atleast_2d(target.X[sample_index])
+        batch_shape = (-1,) + target.model_input_shape
+
+    return out.reshape(batch_shape)


### PR DESCRIPTION
Hi counterfit team,

Thanks for the great project.
I've added a simple Flask application to serve commands as a REST API. Currently it only supports the predict command but can be extended.
I've also added the `serve` command to launch and stop the server.
