### PR TITLE
Feature/sample index

### DIFF
--- a/counterfit/frameworks/secml/GammaPadding.py
+++ b/counterfit/frameworks/secml/GammaPadding.py
@@ -13,9 +13,8 @@ class GammaPaddingAttack(Attack):
     framework = "secml"
 
     default = {
-        'how_many_sections': 75,
-        'which_sections': ['.rdata'],
-        'goodware_folder': None,
+        'section_population': ['.rdata'],
+        # 'goodware_folder': None,
         'population_size': 10,
         'penalty_regularizer': 1e-7,
         'iterations': 100,
@@ -27,9 +26,8 @@ class GammaPaddingAttack(Attack):
     }
 
     random = {
-        'how_many_sections': np.random.randint(10, 100),
-        'which_sections': np.random.choice(['.rdata', '.text', '.reloc', '.data']),
-        'goodware_folder': None,
+        'section_population': np.random.choice(['.rdata', '.text', '.reloc', '.data']),
+        # 'goodware_folder': None,
         'population_size': np.random.randint(5, 20),
         'penalty_regularizer': pow(10, -np.random.randint(4, 8)),
         'iterations': np.random.randint(50, 500),

--- a/counterfit/frameworks/secml/GammeSection.py
+++ b/counterfit/frameworks/secml/GammeSection.py
@@ -11,9 +11,9 @@ class GammaSectionInjectionAttack(Attack):
     category = "blackbox"
     framework = "secml"
     default = {
-        'how_many_sections': 75,
-        'which_sections': ['.rdata'],
-        'goodware_folder': None,
+        #'how_many_sections': 75,
+        'section_population': ['.rdata'],
+        # 'goodware_folder': None,
         'population_size': 10,
         'penalty_regularizer': 1e-7,
         'iterations': 100,
@@ -26,9 +26,9 @@ class GammaSectionInjectionAttack(Attack):
     }
 
     random = {
-        'how_many_sections': np.random.randint(10, 100),
-        'which_sections': np.random.choice(['.rdata', '.text', '.reloc', '.data']),
-        'goodware_folder': None,
+        #'how_many_sections': np.random.randint(10, 100),
+        'section_population': np.random.choice(['.rdata', '.text', '.reloc', '.data']),
+        # 'goodware_folder': None,
         'population_size': np.random.randint(5, 20),
         'penalty_regularizer': pow(10, -np.random.randint(4, 8)),
         'iterations': np.random.randint(50, 500),

--- a/counterfit/targets/pe_malware/ember_secml_target.py
+++ b/counterfit/targets/pe_malware/ember_secml_target.py
@@ -36,6 +36,8 @@ class EmberTarget(SecMLMalwareTarget):
         model = CClassifierEmber(self.model_endpoint)
         self.model = CEmberWrapperPhi(model)
 
+        # store all competition malware samples in memory...
+        # ...to make this possible, saving as a list of bytez w/o padding
         print(f"reading malware samples from {self.sample_input_path}")
         with ZipFile(self.sample_input_path) as thezip:
             thezip.setpassword(self.encryption_password)

--- a/counterfit/targets/pe_malware/ember_secml_target.py
+++ b/counterfit/targets/pe_malware/ember_secml_target.py
@@ -1,0 +1,78 @@
+import os
+import numpy as np
+import magic
+import gzip
+import shutil
+
+from counterfit.core import config
+from secml.array import CArray
+from secml_malware.attack.blackbox.c_wrapper_phi import CEmberWrapperPhi
+from secml_malware.models import CClassifierEmber
+from counterfit.core.targets import SecMLMalwareTarget
+from zipfile import ZipFile
+import tqdm
+
+
+class EmberTarget(SecMLMalwareTarget):
+    model_name = 'ember-secml'
+    model_data_type = "PE"
+    model_output_classes = ["benign", "malicious"]
+    model_input_shape = (1,)
+    model_location = "local"
+    model_endpoint = os.path.join(
+        config.targets_path, 'pe_malware', 'pretrained', 'ember_model.txt')
+
+    sample_input_path = f"{config.targets_path}/pe_malware/samples/MLSEC_samples.zip"
+    encryption_password = b'infected'
+
+    X = []
+
+    def __init__(self):
+        if not os.path.isfile(self.model_endpoint):
+            # gunzip if necessary
+            with gzip.open(self.model_endpoint + '.gz', 'rb') as f_in:
+                with open(self.model_endpoint, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+        model = CClassifierEmber(self.model_endpoint)
+        self.model = CEmberWrapperPhi(model)
+
+        print(f"reading malware samples from {self.sample_input_path}")
+        with ZipFile(self.sample_input_path) as thezip:
+            thezip.setpassword(self.encryption_password)
+            for zipinfo in tqdm.tqdm(thezip.infolist()):
+                with thezip.open(zipinfo, pwd=self.encryption_password) as thefile:
+                    x_i = thefile.read()
+                    self.X.append(x_i)
+
+    def __call__(self, batch):
+        # 'batch' can be a list of bytes or a CArray
+        def helper(xx):
+            xx = xx.atleast_2d()
+            labels, scores = self.model.predict(xx, return_decision_function=True)
+            labels, scores = labels.atleast_2d(), scores.atleast_2d()
+
+            return labels.tondarray(), scores.tondarray()
+
+        try:
+
+            labels, scores = [], []
+            if type(batch) is list or type(batch) is np.ndarray:  # we store nominally as a list of bytez (without padding) for memory efficiency
+                for xx in batch:
+                    if type(xx) is bytes or type(xx) is np.bytes_:
+                        # bytes is nominal, however, after adversarial examples are collected, we receive a list of CArrays that need no conversion
+                        xx = CArray(np.frombuffer(xx, dtype='uint8'))
+                    l, s = helper(xx)
+                    labels.append(l.item())
+                    scores.append(s[0])
+            elif type(batch) is CArray:  # secml requires CArray
+                batch = batch.atleast_2d()
+                for i in range(batch.shape[0]):
+                    l, s = helper(batch[i, :])
+                    labels.append(l.item())
+                    scores.append(s[0])
+
+        except (AttributeError, IndexError):
+            from IPython import embed
+            embed()
+
+        return CArray(labels).tondarray(), CArray(scores).tondarray()

--- a/counterfit/targets/pe_malware/ember_target.py
+++ b/counterfit/targets/pe_malware/ember_target.py
@@ -4,54 +4,65 @@ import magic
 import gzip
 import shutil
 
+
+from counterfit.core.state import ArtTarget
 from counterfit.core import config
-from secml.array import CArray
-from secml_malware.attack.blackbox.c_wrapper_phi import CEmberWrapperPhi
-from secml_malware.models import CClassifierEmber
-from counterfit.core.targets import SecMLMalwareTarget
+from zipfile import ZipFile
+import io
+from ember import PEFeatureExtractor
+import lightgbm as lgb
+import tqdm
 
 
-class EmberTarget(SecMLMalwareTarget):
+class EmberTarget(ArtTarget):
     model_name = 'ember'
-    model_data_type = "PE"
+    model_data_type = "numpy"
     model_output_classes = ["goodware", "malware"]
     model_input_shape = (1,)
     model_location = "local"
     model_endpoint = os.path.join(
         config.targets_path, 'pe_malware', 'pretrained', 'ember_model.txt')
 
-    sample_input_path = f"{config.targets_path}/pe_malware/samples/malware"
+    sample_input_path = f"{config.targets_path}/pe_malware/samples/MLSEC_samples.zip"
+    encryption_password = b'infected'
 
     X = []
 
     def __init__(self):
-        if not os.path.isfile(self.model_endpoint):
-            # gunzip if necessary
-            with gzip.open(self.model_endpoint + '.gz', 'rb') as f_in:
-                with open(self.model_endpoint, 'wb') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
-        model = CClassifierEmber(self.model_endpoint)
-        self.model = CEmberWrapperPhi(model)
+        # load model (gunzip)
+        with gzip.open(self.model_endpoint + '.gz', 'rb') as f_in:
+            model_data = f_in.read().decode('ascii')
 
-        malware_files = os.listdir(self.sample_input_path)
-        max_length = 0
-        xx = []
-        for f in malware_files:
-            complete_path = os.path.join(self.sample_input_path, f)
-            if "PE" not in magic.from_file(complete_path):
-                continue
-            with open(complete_path, 'rb') as h:
-                code = h.read()
-            x_i = np.frombuffer(code, dtype=np.uint8)
-            max_length = max(max_length, len(x_i))
-            xx.append(x_i)
-        self.X = [np.append(x_i, [256] * (max_length - len(x_i))
-                            ).astype(np.uint8) for x_i in xx]
+        self.model = lgb.Booster(model_str=model_data)
+        self.extractor = PEFeatureExtractor(2)  # feature_version=2
+        self.thresh = 0.8336
 
-    def __call__(self, x):
-        if type(x) != CArray:
-            x = CArray(x)
-        x = x.atleast_2d()
-        labels, scores = self.model.predict(x, return_decision_function=True)
-        labels, scores = labels.atleast_2d(), scores.atleast_2d()
-        return labels.tondarray(), scores.tondarray()
+        print(f"reading malware samples from {self.sample_input_path}")
+        self.X = []
+        with ZipFile(self.sample_input_path) as thezip:
+            thezip.setpassword(self.encryption_password)
+            for zipinfo in tqdm.tqdm(thezip.infolist()):
+                with thezip.open(zipinfo, pwd=self.encryption_password) as thefile:
+                    self.X.append(thefile.read())
+
+
+    def set_attack_samples(self, index=0):
+        if hasattr(index, "__iter__"):
+            # list of indices
+            out = np.array([self.X[i] for i in index])
+        else:
+            out = self.X[index]
+        
+        self.active_attack.sample_index = index
+        self.active_attack.samples = out
+
+    def __call__(self, batch):
+        features = []
+        for bytez in batch:
+            feat = np.array(self.extractor.feature_vector(bytez.tobytes()), dtype=np.float32)
+            features.append(feat)
+        
+        scores = np.array(self.model.predict(features))
+        labels = scores > self.thresh
+        
+        return labels

--- a/counterfit/targets/pe_malware/malconv_secml_target.py
+++ b/counterfit/targets/pe_malware/malconv_secml_target.py
@@ -7,16 +7,20 @@ from secml.array import CArray
 from secml_malware.attack.blackbox.c_wrapper_phi import CEnd2EndWrapperPhi
 from secml_malware.models import CClassifierEnd2EndMalware, MalConv
 from counterfit.core.targets import SecMLMalwareTarget
+from zipfile import ZipFile
+import tqdm
 
 
 class MalConvTarget(SecMLMalwareTarget):
-    model_name = 'malconv'
+    model_name = 'malconv-secml'
     model_data_type = "PE"
-    model_output_classes = ["goodware", "malware"]
+    model_output_classes = ["benign", "malicious"]
     model_input_shape = (1, )
     model_location = "local"
-    model_endpoint = 'included inside secml-malware'
-    sample_input_path = f"{config.targets_path}/pe_malware/samples/malware"
+    model_endpoint = '(included in secml-malware)'
+
+    sample_input_path = f"{config.targets_path}/pe_malware/samples/MLSEC_samples.zip"
+    encryption_password = b'infected'
 
     X = []
 
@@ -25,17 +29,18 @@ class MalConvTarget(SecMLMalwareTarget):
         model.load_pretrained_model()
         self.model = CEnd2EndWrapperPhi(model)
 
-        malware_files = os.listdir(self.sample_input_path)
-        max_length = 0
+        print(f"reading malware samples from {self.sample_input_path}")
         xx = []
-        for f in malware_files:
-            complete_path = os.path.join(self.sample_input_path, f)
+        max_length = 0
+        with ZipFile(self.sample_input_path) as thezip:
+            thezip.setpassword(self.encryption_password)
+            for zipinfo in tqdm.tqdm(thezip.infolist()):
+                with thezip.open(zipinfo, pwd=self.encryption_password) as thefile:
+                    x_i = thefile.read()
+                    xx.append(x_i)
+                    max_length = max(max_length, len(x_i))                    
 
-            with open(complete_path, 'rb') as h:
-                code = h.read()
-            x_i = np.frombuffer(code, dtype=np.uint8)
-            max_length = max(max_length, len(x_i))
-            xx.append(x_i)
+
         self.X = [np.append(x_i, [256] * (max_length - len(x_i))
                             ).astype(np.uint8) for x_i in xx]
 

--- a/counterfit/targets/pe_malware/malconv_secml_target.py
+++ b/counterfit/targets/pe_malware/malconv_secml_target.py
@@ -29,6 +29,8 @@ class MalConvTarget(SecMLMalwareTarget):
         model.load_pretrained_model()
         self.model = CEnd2EndWrapperPhi(model)
 
+        # store all competition malware samples in memory...
+        # ...to make this possible, saving as a list of bytez w/o padding
         print(f"reading malware samples from {self.sample_input_path}")
         xx = []
         max_length = 0


### PR DESCRIPTION
- `set` now evaluate a Python expression in the rvalue of a `set lvalue=rvalue` by using ticks ``set sample_index=`[0,1]` ``
- updated to work with batches so that contestants can operate on all samples at a time (and save results for active samples)
- mlsec targets renamed
- mlsec targets read from encrypted ZIP file
- mlsec targets can use batches
- disabled saving to disk temporarily