### PR TITLE
replace python-Levenshtein with rapidfuzz

### DIFF
--- a/counterfit/core/run_scan_utils.py
+++ b/counterfit/core/run_scan_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-import Levenshtein  # pip install python-Levenshtein
+from rapidfuzz import string_metric  # pip install rapidfuzz
 from cmd2.table_creator import Column, SimpleTable, HorizontalAlignment
 from cmd2 import ansi
 from typing import Any, List
@@ -74,7 +74,7 @@ def get_run_summary(target, attack=None):
     if target.model_data_type == "text":
         # Levenshtein distance
         metric = "% edit dist."
-        distances = [Levenshtein.distance(iif, ii0) for iif, ii0 in zip(i_f, i_0)]
+        distances = [string_metric.levenshtein(iif, ii0) for iif, ii0 in zip(i_f, i_0)]
         rel_distance = [d / len(ii0) for d, ii0 in zip(distances, i_0)]
     elif target.model_data_type == "numpy" or target.model_data_type == "image":
         # l2 norm

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /home/counterfituser
 COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install tensorflow python-Levenshtein
+RUN pip install tensorflow rapidfuzz
 
 USER counterfituser
 

--- a/infrastructure/DockerfileCounterfitJupyterlab.dockerfile
+++ b/infrastructure/DockerfileCounterfitJupyterlab.dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
 USER 1000
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt 
-RUN pip install tensorflow python-Levenshtein
+RUN pip install tensorflow rapidfuzz
 RUN git clone https://github.com/Azure/counterfit.git \
    && cd counterfit \
    && python -c 'import ssl, nltk; ssl._create_default_https_context = ssl._create_unverified_context; nltk.download("stopwords")' \

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests==2.24.0
 hyperopt==0.2.3
 scipy==1.4.1
 questionary==1.9.0
-python-Levenshtein==0.12.2
+rapidfuzz==1.8.2
 
 # frameworks
 adversarial-robustness-toolbox>=1.5


### PR DESCRIPTION
Currently python-Levenshtein is the only GPL licensed dependency of counterfit. This pr replaces it with rapidfuzz, which is MIT licensed and faster.